### PR TITLE
Remove redundant loop when assigning a seed to a set of subkeys

### DIFF
--- a/mph.go
+++ b/mph.go
@@ -69,11 +69,9 @@ func New(keys []string) *Table {
 			values[k] = v
 		}
 
-		// and assign this seed value for every subkey
-		for _, k := range subkeys {
-			i := k.hash % size
-			seeds[i] = int32(seed)
-		}
+		// and assign this seed value for these subkeys
+		i := subkeys[0].hash % size
+		seeds[i] = int32(seed)
 	}
 
 	// find the unassigned entries in the table


### PR DESCRIPTION
Every key within a subkey is guaranteed to get the same result when doing `hash % size`, so when assigning the seed, we can just look at the first key instead of looping through all keys.