### PR TITLE
Out of bounds fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/serbanoprea/go-mph
+
+go 1.24.5
+
+require github.com/cespare/xxhash/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/mph.go
+++ b/mph.go
@@ -154,7 +154,11 @@ func NewUint64(keys []uint64) (*Table, error) {
 	}, nil
 }
 
-func (t *Table) Query(hash uint64) int32 {
+func (t *Table) Query(k string) int32 {
+	return t.QueryUint64(xxhash.Sum64String(k))
+}
+
+func (t *Table) QueryUint64(hash uint64) int32 {
 	if len(t.Values) == 0 {
 		return -1
 	}

--- a/mph_test.go
+++ b/mph_test.go
@@ -63,7 +63,7 @@ func testMPHU64(t *testing.T, keys []uint64) {
 		t.Fatal(err)
 	}
 	for i, k := range keys {
-		if got := tab.Query(k); got != int32(i) {
+		if got := tab.QueryUint64(k); got != int32(i) {
 			t.Errorf("Lookup(%v)=%v, want %v", k, got, i)
 		}
 	}
@@ -96,8 +96,8 @@ func TestMPH_Determinism(t *testing.T) {
 		t.Fatal(err)
 	}
 	for i, k := range keys {
-		g1 := tab1.Query(k)
-		g2 := tab2.Query(k)
+		g1 := tab1.QueryUint64(k)
+		g2 := tab2.QueryUint64(k)
 		if g1 != g2 || g1 != int32(i) {
 			t.Fatalf("determinism failure: key[%d]=%v -> (%d,%d), want %d", i, k, g1, g2, i)
 		}
@@ -138,7 +138,7 @@ func BenchmarkMPH_U64(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		for _, k := range keys {
-			sinkI32 += tab.Query(k)
+			sinkI32 += tab.QueryUint64(k)
 		}
 	}
 }

--- a/mph_test.go
+++ b/mph_test.go
@@ -7,17 +7,20 @@ import (
 	"math/rand"
 	"os"
 	"testing"
+
+	"github.com/cespare/xxhash/v2"
 )
 
-var keysFile = flag.String("keys", "", "load keys datafile")
+var keysFile = flag.String("keys", "", "load keys datafile (one key per line)")
 
-func loadKeys(tb testing.TB) []string {
+func loadKeysU64(tb testing.TB) []uint64 {
+	tb.Helper()
 
 	if *keysFile != "" {
-		return loadBigKeys(tb, *keysFile)
+		return loadBigKeysU64(tb, *keysFile)
 	}
 
-	return []string{
+	base := []string{
 		"foo",
 		"bar",
 		"baz",
@@ -27,81 +30,130 @@ func loadKeys(tb testing.TB) []string {
 		"zork",
 		"zeek",
 	}
+	out := make([]uint64, len(base))
+	for i, s := range base {
+		out[i] = xxhash.Sum64String(s)
+	}
+	return out
 }
 
-func loadBigKeys(tb testing.TB, filename string) []string {
+func loadBigKeysU64(tb testing.TB, filename string) []uint64 {
+	tb.Helper()
+
 	f, err := os.Open(filename)
 	if err != nil {
-		tb.Fatalf("unable to keys file: %v", err)
+		tb.Fatalf("unable to open keys file: %v", err)
 	}
 	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
-	var k []string
-	for scanner.Scan() {
-		k = append(k, scanner.Text())
+	var ks []uint64
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		ks = append(ks, xxhash.Sum64String(sc.Text()))
 	}
-
-	return k
+	if err := sc.Err(); err != nil {
+		tb.Fatalf("error reading keys file: %v", err)
+	}
+	return ks
 }
 
-func testMPH(t *testing.T, keys []string) {
-	tab := New(keys)
+func testMPHU64(t *testing.T, keys []uint64) {
+	tab, err := NewUint64(keys)
+	if err != nil {
+		t.Fatal(err)
+	}
 	for i, k := range keys {
 		if got := tab.Query(k); got != int32(i) {
-			t.Errorf("Lookup(%q)=%v, want %v", k, got, i)
+			t.Errorf("Lookup(%v)=%v, want %v", k, got, i)
 		}
 	}
 }
 
-func TestMPH(t *testing.T) {
-	keys := loadKeys(t)
-	testMPH(t, keys)
+func TestMPH_U64(t *testing.T) {
+	keys := loadKeysU64(t)
+	testMPHU64(t, keys)
 }
 
-func TestMPHRandomSubsets(t *testing.T) {
-	keys := loadKeys(t)
+func TestMPH_Empty(t *testing.T) {
+	var keys []uint64
+	// would panic in intial implementation
+	tab, err := NewUint64(keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = tab
+}
+
+func TestMPH_Determinism(t *testing.T) {
+	keys := loadKeysU64(t)
+
+	tab1, err := NewUint64(keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tab2, err := NewUint64(keys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, k := range keys {
+		g1 := tab1.Query(k)
+		g2 := tab2.Query(k)
+		if g1 != g2 || g1 != int32(i) {
+			t.Fatalf("determinism failure: key[%d]=%v -> (%d,%d), want %d", i, k, g1, g2, i)
+		}
+	}
+}
+
+func TestMPH_RandomSubsets_U64(t *testing.T) {
+	keys := loadKeysU64(t)
 
 	iterations := 100 * len(keys)
+	if iterations == 0 {
+		iterations = 100
+	}
 
 	for i := 0; i < iterations; i++ {
-		perm := rand.Perm(rand.Intn(len(keys)))
-		subkeys := make([]string, len(perm))
-		for i, v := range perm {
-			subkeys[i] = keys[v]
+		n := rand.Intn(len(keys) + 1)
+		perm := rand.Perm(len(keys))[:n]
+		sub := make([]uint64, n)
+		for j, v := range perm {
+			sub[j] = keys[v]
 		}
 
-		t.Run(fmt.Sprintf("%d-%d", i, len(subkeys)), func(t *testing.T) { testMPH(t, subkeys) })
+		t.Run(fmt.Sprintf("%d-%d", i, len(sub)), func(t *testing.T) {
+			testMPHU64(t, sub)
+		})
 	}
 }
 
-var sink int32
+var sinkI32 int32
 
-func BenchmarkMPH(b *testing.B) {
-	keys := loadKeys(b)
-	tab := New(keys)
+func BenchmarkMPH_U64(b *testing.B) {
+	keys := loadKeysU64(b)
+	tab, err := NewUint64(keys)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	b.ResetTimer()
-
 	for i := 0; i < b.N; i++ {
 		for _, k := range keys {
-			sink += tab.Query(k)
+			sinkI32 += tab.Query(k)
 		}
 	}
 }
 
-func BenchmarkMap(b *testing.B) {
-	keys := loadKeys(b)
-	m := make(map[string]int32, len(keys))
+func BenchmarkMap_U64(b *testing.B) {
+	keys := loadKeysU64(b)
+	m := make(map[uint64]int32, len(keys))
 	for i, k := range keys {
 		m[k] = int32(i)
 	}
 
 	b.ResetTimer()
-
 	for i := 0; i < b.N; i++ {
 		for _, k := range keys {
-			sink += m[k]
+			sinkI32 += m[k]
 		}
 	}
 }


### PR DESCRIPTION
The reason for the refactor is that this part occasionally tries to access values that are out of bounds for the `.Values` array. 
```
seed := t.Seeds[i]
if seed < 0 {
return t.Values[-seed-1]
}
```